### PR TITLE
adding create.sql script for creating the accounts and doors tables

### DIFF
--- a/database/create.sql
+++ b/database/create.sql
@@ -1,0 +1,14 @@
+CREATE DATABASE IF NOT EXISTS SmartLatch;
+USE SmartLatch;
+CREATE TABLE IF NOT EXISTS Accounts (
+    user_id_num INT PRIMARY KEY,
+    email VARCHAR(320) NOT NULL UNIQUE,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NOT NULL,
+    username VARCHAR(255) NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS UserDoors (
+    user_id_num INT NOT NULL,
+    door_id INT NOT NULL UNIQUE,
+    FOREIGN KEY(user_id_num) REFERENCES Accounts(user_id_num)
+);


### PR DESCRIPTION
Adding script to create the MySQL database on the GCP backend. 

To run the script execute
`source create.sql;`
after logging into MySQL prompt.

Creates the following tables under _SmartLatch_
![db](https://user-images.githubusercontent.com/35539701/108506568-ecf19d00-72b0-11eb-8751-a789859b27ae.PNG)

Unfortunately there were no relational DBs with completely free tiers, but we can change this stuff around.

